### PR TITLE
Update to KDE Platform 5.15

### DIFF
--- a/org.quassel_irc.QuasselClient.json
+++ b/org.quassel_irc.QuasselClient.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.quassel_irc.QuasselClient",
     "runtime": "org.kde.Platform",
-    "runtime-version": "5.13",
+    "runtime-version": "5.15",
     "sdk": "org.kde.Sdk",
     "command": "quasselclient",
     "rename-icon": "quassel",
@@ -40,6 +40,10 @@
                     "type": "archive",
                     "url": "https://quassel-irc.org/pub/quassel-0.13.1.tar.bz2",
                     "sha256": "48efee9778743b1db9f44efb91d1c913104db01190c57f2ff57483c39a97e855"
+                },
+                {
+                    "type": "patch",
+                    "path": "quassel-0.13.1-qt5.14.patch"
                 }
             ],
             "modules": [

--- a/org.quassel_irc.QuasselClient.json
+++ b/org.quassel_irc.QuasselClient.json
@@ -75,8 +75,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.kde.org/stable/plasma/5.16.3/oxygen-5.16.3.tar.xz",
-                    "sha256": "552b008ec09d08c4704aa3ea66b2d73cf98dc35be290792d34d7962c59f51544"
+                    "url": "https://download.kde.org/stable/plasma/5.20.3/oxygen-5.20.3.tar.xz",
+                    "sha256": "8c6c5068065f3989d836770ec677d883b0650afdeb2e495d49c9c0adf6e834ea"
                 }
             ]
         }

--- a/quassel-0.13.1-qt5.14.patch
+++ b/quassel-0.13.1-qt5.14.patch
@@ -1,0 +1,118 @@
+commit c90702bdbc43fc542d7df6d5ec4b321912ca0035
+Author: Manuel Nickschas <sputnick@quassel-irc.org>
+Date:   Tue Jan 7 18:34:54 2020 +0100
+
+    common: Disable enum type stream operators for Qt >= 5.14
+    
+    Starting from version 5.14, Qt provides stream operators for enum
+    types, which collide with the ones we ship in types.h. Disable
+    Quassel's stream operators when compiling against Qt 5.14 or later.
+    
+    Add a unit test that ensures that enum serialization honors the width
+    of the underlying type.
+
+diff --git a/src/common/types.h b/src/common/types.h
+index 467d9fb2..c4b9f364 100644
+--- a/src/common/types.h
++++ b/src/common/types.h
+@@ -140,6 +140,7 @@ Q_DECLARE_METATYPE(QHostAddress)
+ typedef QList<MsgId> MsgIdList;
+ typedef QList<BufferId> BufferIdList;
+ 
++#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+ /**
+  * Catch-all stream serialization operator for enum types.
+  *
+@@ -169,6 +170,7 @@ QDataStream &operator>>(QDataStream &in, T &value) {
+     value = static_cast<T>(v);
+     return in;
+ }
++#endif
+ 
+ // Exceptions
+ 
+diff --git a/src/common/typestest.cpp b/src/common/typestest.cpp
+new file mode 100644
+index 00000000..04031c29
+--- /dev/null
++++ b/src/common/typestest.cpp
+@@ -0,0 +1,79 @@
++/***************************************************************************
++ *   Copyright (C) 2005-2020 by the Quassel Project                        *
++ *   devel@quassel-irc.org                                                 *
++ *                                                                         *
++ *   This program is free software; you can redistribute it and/or modify  *
++ *   it under the terms of the GNU General Public License as published by  *
++ *   the Free Software Foundation; either version 2 of the License, or     *
++ *   (at your option) version 3.                                           *
++ *                                                                         *
++ *   This program is distributed in the hope that it will be useful,       *
++ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
++ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
++ *   GNU General Public License for more details.                          *
++ *                                                                         *
++ *   You should have received a copy of the GNU General Public License     *
++ *   along with this program; if not, write to the                         *
++ *   Free Software Foundation, Inc.,                                       *
++ *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
++ ***************************************************************************/
++
++#include <cstdint>
++
++#include <QByteArray>
++#include <QDataStream>
++#include <QObject>
++
++#include "testglobal.h"
++#include "types.h"
++
++using namespace ::testing;
++
++class EnumHolder
++{
++    Q_GADGET
++
++public:
++    enum class Enum16 : uint16_t {};
++    enum class Enum32 : uint32_t {};
++
++    enum class EnumQt16 : uint16_t {};
++    Q_ENUM(EnumQt16)
++    enum class EnumQt32 : uint32_t {};
++    Q_ENUM(EnumQt32)
++};
++
++// Verify that enums are (de)serialized as their underlying type
++TEST(TypesTest, enumSerialization)
++{
++    QByteArray data;
++    QDataStream out(&data, QIODevice::WriteOnly);
++
++    // Serialize
++    out << EnumHolder::Enum16(0xabcd);
++    ASSERT_THAT(data.size(), Eq(2));
++    out << EnumHolder::Enum32(0x123456);
++    ASSERT_THAT(data.size(), Eq(6));
++    out << EnumHolder::EnumQt16(0x4321);
++    ASSERT_THAT(data.size(), Eq(8));
++    out << EnumHolder::Enum32(0xfedcba);
++    ASSERT_THAT(data.size(), Eq(12));
++    ASSERT_THAT(out.status(), Eq(QDataStream::Status::Ok));
++
++    // Deserialize
++    QDataStream in(data);
++    EnumHolder::Enum16 enum16;
++    EnumHolder::Enum32 enum32;
++    EnumHolder::EnumQt16 enumQt16;
++    EnumHolder::EnumQt32 enumQt32;
++    in >> enum16  >> enum32 >> enumQt16 >> enumQt32;
++    ASSERT_THAT(in.status(), Eq(QDataStream::Status::Ok));
++    EXPECT_TRUE(in.atEnd());
++
++    EXPECT_THAT((int)enum16, Eq(0xabcd));
++    EXPECT_THAT((int)enum32, Eq(0x123456));
++    EXPECT_THAT((int)enumQt16, Eq(0x4321));
++    EXPECT_THAT((int)enumQt32, Eq(0xfedcba));
++}
++
++#include "typestest.moc"


### PR DESCRIPTION
- Include a patch (version from [Arch Linux](https://github.com/archlinux/svntogit-community/blob/packages/quassel/trunk/quassel-0.13.1-qt5.14.patch)) already [merged upstream](https://github.com/quassel/quassel/pull/518) to fix issues with Qt 5.14+.
- Update Oxygen sound theme to 5.20.3