### PR TITLE
Update KDE runtime and Boost

### DIFF
--- a/org.quassel_irc.QuasselClient.appdata.xml
+++ b/org.quassel_irc.QuasselClient.appdata.xml
@@ -27,8 +27,9 @@
     <content_attribute id="social-info">mild</content_attribute>
   </content_rating>
   <provides>
-    <id>quasselclient.desktop</id>
+    <id>org.quassel_irc.QuasselClient.desktop</id>
   </provides>
+  <launchable type="desktop-id">org.quassel_irc.QuasselClient.desktop</launchable>
   <releases>
     <release version="0.14.0" date="2022-01-01" />
     <release version="0.13.1" date="2019-02-15" />

--- a/org.quassel_irc.QuasselClient.appdata.xml
+++ b/org.quassel_irc.QuasselClient.appdata.xml
@@ -17,8 +17,9 @@
     <p>By modern we mean that Quassel IRC will have all the features you'd expect from an IRC client nowadays. It also innovates in many areas. For example, the GUI features a dockable nicklist and topic bar, or you can arrange your channel and query buffers in default or custom views, which are also dockable. This means that you can arrange your GUI as you please. The architecture allows for other innovations, such as on-demand creation of log files in custom formats from the backlog.</p>
   </description>
   <screenshots>
-    <screenshot>
+    <screenshot type="default">
       <image type="source">https://quassel-irc.org/files/images/snapshot13.png</image>
+      <caption>Chat view with dark theme</caption>
     </screenshot>
   </screenshots>
   <content_rating type="oars-1.1">

--- a/org.quassel_irc.QuasselClient.json
+++ b/org.quassel_irc.QuasselClient.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.quassel_irc.QuasselClient",
     "runtime": "org.kde.Platform",
-    "runtime-version": "5.15-23.08",
+    "runtime-version": "5.15-24.08",
     "sdk": "org.kde.Sdk",
     "command": "quasselclient",
     "rename-icon": "quassel",

--- a/org.quassel_irc.QuasselClient.json
+++ b/org.quassel_irc.QuasselClient.json
@@ -57,13 +57,13 @@
                     "sources": [
                         {
                             "type": "archive",
-                            "url": "https://boostorg.jfrog.io/artifactory/main/release/1.79.0/source/boost_1_79_0.tar.bz2",
-                            "sha256": "475d589d51a7f8b3ba2ba4eda022b170e562ca3b760ee922c146b6c65856ef39",
+                            "url": "https://archives.boost.io/release/1.88.0/source/boost_1_88_0.tar.bz2",
+                            "sha256": "46d9d2c06637b219270877c9e16155cbd015b6dc84349af064c088e9b5b12f7b",
                             "x-checker-data": {
                                 "type": "anitya",
                                 "project-id": 6845,
                                 "stable-only": true,
-                                "url-template": "https://boostorg.jfrog.io/artifactory/main/release/$version/source/boost_${major}_${minor}_${patch}.tar.bz2"
+                                "url-template": "https://archives.boost.io/release/$version/source/boost_${major}_${minor}_$patch.tar.bz2"
                             }
                         }
                     ],


### PR DESCRIPTION
Adapt appdata to address new linter errors.