### PR TITLE
Update KDE runtime to 5.15-25.08 and more

### DIFF
--- a/CMake-satisfy-KDE-runtime-25.08-requirements.patch
+++ b/CMake-satisfy-KDE-runtime-25.08-requirements.patch
@@ -1,0 +1,24 @@
+From 0a8d3a7a3b337262816da5bbaa45c3fc50975703 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Christian=20G=C3=B6ttsche?= <cgoettsche@seltendoof.de>
+Date: Mon, 5 Jan 2026 17:04:35 +0100
+Subject: [PATCH] CMake: satisfy KDE runtime 25.08 requirements
+
+---
+ CMakeLists.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5a6b337..119fad8 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,5 +1,5 @@
+-project( SnoreNotify )
+-cmake_minimum_required( VERSION 2.8.12 )
++project( SnoreNotify VERSION 0.7.0 )
++cmake_minimum_required( VERSION 3.5 )
+ 
+ include(FeatureSummary)
+ 
+-- 
+2.52.0
+

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "require-important-update": true
+}

--- a/org.quassel_irc.QuasselClient.json
+++ b/org.quassel_irc.QuasselClient.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.quassel_irc.QuasselClient",
     "runtime": "org.kde.Platform",
-    "runtime-version": "5.15-24.08",
+    "runtime-version": "5.15-25.08",
     "sdk": "org.kde.Sdk",
     "command": "quasselclient",
     "rename-icon": "quassel",
@@ -85,6 +85,10 @@
                             "type": "archive",
                             "url": "https://download.kde.org/stable/snorenotify/0.7.0/src/snorenotify-0.7.0.tar.xz",
                             "sha256": "6d411ba6e31a73db56d298195f8336f66f8fe4fffd64d5fde3f14090e68ee64b"
+                        },
+                        {
+                            "type": "patch",
+                            "path": "CMake-satisfy-KDE-runtime-25.08-requirements.patch"
                         }
                     ]
                 }

--- a/org.quassel_irc.QuasselClient.json
+++ b/org.quassel_irc.QuasselClient.json
@@ -28,7 +28,7 @@
                 "-DENABLE_SHARED=0"
             ],
             "post-install": [
-                "install -Dm644 org.quassel_irc.QuasselClient.appdata.xml /app/share/appdata/org.quassel_irc.QuasselClient.appdata.xml"
+                "install -Dm644 org.quassel_irc.QuasselClient.appdata.xml -t /app/share/metainfo/"
             ],
             "sources": [
                 {

--- a/org.quassel_irc.QuasselClient.json
+++ b/org.quassel_irc.QuasselClient.json
@@ -57,8 +57,8 @@
                     "sources": [
                         {
                             "type": "archive",
-                            "url": "https://archives.boost.io/release/1.88.0/source/boost_1_88_0.tar.bz2",
-                            "sha256": "46d9d2c06637b219270877c9e16155cbd015b6dc84349af064c088e9b5b12f7b",
+                            "url": "https://archives.boost.io/release/1.91.0/source/boost_1_91_0.tar.bz2",
+                            "sha256": "de5e6b0e4913395c6bdfa90537febd9028ea4c0735d2cdb0cd9b45d5f51264f5",
                             "x-checker-data": {
                                 "type": "anitya",
                                 "project-id": 6845,

--- a/org.quassel_irc.QuasselClient.json
+++ b/org.quassel_irc.QuasselClient.json
@@ -46,6 +46,7 @@
                     "url": "https://quassel-irc.org/pub/quassel-0.14.0.tar.xz",
                     "sha256": "090777f37a6ae1057a046d5c2896ce5e4bef2382377e3ba52c63efe6b5fe4e10",
                     "x-checker-data": {
+                        "is-main-source": true,
                         "type": "html",
                         "url": "https://quassel-irc.org/pub/",
                         "pattern": "(quassel-(\\d+\\.\\d+\\.\\d+)\\.tar\\.xz)"

--- a/org.quassel_irc.QuasselClient.json
+++ b/org.quassel_irc.QuasselClient.json
@@ -60,6 +60,10 @@
                 {
                     "name": "boost",
                     "buildsystem": "simple",
+                    "build-commands": [
+                        "./bootstrap.sh --prefix=/app --with-libraries=headers",
+                        "./b2 variant=release link=shared runtime-link=shared -j $FLATPAK_BUILDER_N_JOBS install"
+                    ],
                     "sources": [
                         {
                             "type": "archive",
@@ -72,10 +76,6 @@
                                 "url-template": "https://archives.boost.io/release/$version/source/boost_${major}_${minor}_$patch.tar.bz2"
                             }
                         }
-                    ],
-                    "build-commands": [
-                        "./bootstrap.sh --prefix=/app --with-libraries=headers",
-                        "./b2 variant=release link=shared runtime-link=shared -j $FLATPAK_BUILDER_N_JOBS install"
                     ]
                 },
                 {

--- a/org.quassel_irc.QuasselClient.json
+++ b/org.quassel_irc.QuasselClient.json
@@ -17,6 +17,12 @@
         "--talk-name=org.freedesktop.DockManager",
         "--talk-name=net.launchpad.DockManager"
     ],
+    "cleanup": [
+        "/include",
+        "/lib/cmake",
+        "/mkspecs",
+        "/lib/pkgconfig"
+    ],
     "modules": [
         {
             "name": "quasselclient",
@@ -109,9 +115,5 @@
                 }
             ]
         }
-    ],
-    "cleanup-commands": [
-        "rm -rf /app/include",
-        "rm -rf /app/lib/{cmake,mkspecs,pkgconfig}"
     ]
 }


### PR DESCRIPTION
- Update KDE runtime to 5.15-25.08
- Add patch to update snorenotify for KDE runtime 25.08
- Update the boos.io module
- Mark the Quassel module as the main source to stop boost module-related noise.